### PR TITLE
Fix: support Infolists\Components\Actions

### DIFF
--- a/src/Infolists/Components/TableRepeatableEntry.php
+++ b/src/Infolists/Components/TableRepeatableEntry.php
@@ -27,9 +27,9 @@ class TableRepeatableEntry extends RepeatableEntry
 
         foreach ($components as $component) {
             $this->columnLabels[] = [
-                'component' => $component->getName(),
+                'component' =>  method_exists($component, 'getName') ? $component->getName(): null,
                 'name' => $component->getLabel(),
-                'alignment' => $component->getAlignment()
+                'alignment' => method_exists($component, 'getAlignment') ? $component->getAlignment(): null
             ];
         }
     }


### PR DESCRIPTION
This pull request includes a small but important change to the `setColumnLabels` method in the `TableRepeatableEntry` class. The change ensures that the methods `getName` and `getAlignment` are checked for existence before being called, preventing potential errors if these methods are not defined on the component.

* [`src/Infolists/Components/TableRepeatableEntry.php`](diffhunk://#diff-7d49964c286d748b080329b384f64ae77a9cc35f86b89305d93231cd774fa646L30-R32): Modified `setColumnLabels` to check for the existence of `getName` and `getAlignment` methods before calling them.